### PR TITLE
Adding the fact that an encrypted column must be of type binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ class MyModel < ActiveRecord::Base
 end
 ```
 
+NOTE: In order for the encrypted data to be store the column must be of type `binary`.
+
 The coder provides a simple API to help you provide search support by
 leveraging the Arel API:
 


### PR DESCRIPTION
Adding the gem to my project I got an error when trying to store the encrypted data to a `string` column and then realized that it should be a binary.

This PR aims at making this information more accessible from the README.