### PR TITLE
Add Ruby 3.1 and Rails 7.0 to CI, Get Rubocop Passing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.6
+        image: postgres:14
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -19,20 +19,30 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.7, 3.0]
-        rails: [4, 5, 6]
+        ruby: [2.4, 2.7, '3.0', 3.1]
+        rails: [4, 5, 6.0, 6.1, 7.0]
         exclude:
           - ruby: 2.4
-            rails: 6
+            rails: 6.0
+          - ruby: 2.4
+            rails: 6.1
+          - ruby: 2.4
+            rails: 7.0
           - ruby: 2.7
             rails: 4
-          - ruby: 3
+          - ruby: '3.0'
             rails: 4
-          - ruby: 3
+          - ruby: '3.0'
             rails: 5
+          - ruby: 3.1
+            rails: 4
+          - ruby: 3.1
+            rails: 5
+          - ruby: 3.1
+            rails: 6.0
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Style/StringLiterals:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 80
 
 Metrics/BlockLength:

--- a/active_record-pgcrypto.gemspec
+++ b/active_record-pgcrypto.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files        += %w[LICENSE.txt README.md]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', (ENV['RAILS_VERSION'] || '>= 3.2')
+  spec.add_dependency 'activerecord', ENV.fetch('RAILS_VERSION', '>= 3.2')
 
   pg_version = '< 1' if ENV['RAILS_VERSION'].to_s.split.last.to_i == 4
 
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yardstick'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/active_record/pgcrypto/symmetric_coder.rb
+++ b/lib/active_record/pgcrypto/symmetric_coder.rb
@@ -3,13 +3,13 @@ module ActiveRecord
     # PGCrypto symmetric encryption/decryption coder for attribute serialization
     module SymmetricCoder
       mattr_accessor :pgcrypto_key do
-        ENV['PGCRYPTO_SYM_KEY']
+        ENV.fetch('PGCRYPTO_SYM_KEY', nil)
       end
       mattr_accessor :pgcrypto_options do
-        ENV['PGCRYPTO_SYM_OPTIONS'] || 'cipher-algo=aes256, unicode-mode=1'
+        ENV.fetch('PGCRYPTO_SYM_OPTIONS', 'cipher-algo=aes256, unicode-mode=1')
       end
       mattr_accessor :pgcrypto_encoding do
-        Encoding.find(ENV['PGCRYPTO_ENCODING'] || 'utf-8')
+        Encoding.find(ENV.fetch('PGCRYPTO_ENCODING', 'utf-8'))
       end
 
       # Decrypts the requested value

--- a/spec/dummy.rb
+++ b/spec/dummy.rb
@@ -2,8 +2,8 @@ require 'active_record'
 require 'logger'
 
 ActiveRecord::Base.logger = Logger.new($stdout)
-ActiveRecord::Base.logger.level = ENV['LOG_LEVEL'] || Logger::WARN
-ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
+ActiveRecord::Base.logger.level = ENV.fetch('LOG_LEVEL') { Logger::WARN }
+ActiveRecord::Base.establish_connection(ENV.fetch('DATABASE_URL', nil))
 
 ActiveRecord::Schema.define do
   enable_extension 'pgcrypto'


### PR DESCRIPTION

## What is the current behavior?

Ruby 3.1 and Rails 7.0 aren't tested
Rubocop doesn't pass
GitHub Actions don't get updated.

## What is the new behavior?

Addresses lints from more recent versions of Rubocop.
Also adds Dependabot for GitHub Actions.

## Checklist

Please make sure the following requirements are complete:

- Tests for the changes have been added (for bug fixes / features) - N/A
- Docs have been reviewed and added / updated if needed (for bug fixes /
  features) - N/A
- [X] All automated checks pass (CI/CD)
