### PR TITLE
Quote the 7.0 to prevent truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.7, '3.0', 3.1, 3.2]
-        rails: [5, 6.0, 6.1, 7.0, 7.1]
+        rails: [5, 6.0, 6.1, '7.0', 7.1]
         exclude:
           - ruby: '3.0'
             rails: 5


### PR DESCRIPTION
## What is the current behavior?

The Rails 7.0 entry in the matrix actually loads 7.1.0, because the 7.0 is trunctated to 7

## What is the new behavior?

The quoted 7.0 is not truncated, and a 7.0.x version is loaded for this matrix entry.

## Checklist

Please make sure the following requirements are complete:

- [X] All automated checks pass (CI/CD)

Here's the action showing this:
<img width="1519" alt="Screenshot 2023-10-08 at 5 08 25 PM" src="https://github.com/stas/active_record-pgcrypto/assets/421488/89d8cace-a191-4123-8b66-37ea1cf77092">
